### PR TITLE
Fix pmid for signatures annotations

### DIFF
--- a/pronto/api/entry/signatures.py
+++ b/pronto/api/entry/signatures.py
@@ -350,6 +350,7 @@ def get_signatures_annotations(accession):
 
     signatures = []
     for accession, name, text in cur:
+        # TODO: remove after DB is updated
         #format citations coming from signatures
         if text and re.search(r'PMID', text):
             regex_replacements = [(r']',']]'),('PMID:\s*','[cite:'),(r', \[', '], [')]

--- a/pronto/api/entry/signatures.py
+++ b/pronto/api/entry/signatures.py
@@ -350,6 +350,11 @@ def get_signatures_annotations(accession):
 
     signatures = []
     for accession, name, text in cur:
+        #format citations coming from signatures
+        if text and re.search(r'PMID', text):
+            REGEX_REPLACEMENTS = [(r']',']]'),('PMID: ','[cite:'),(r', \[', '], [')]
+            for old, new in REGEX_REPLACEMENTS:
+                text=re.sub(old, new, text)
         signatures.append({
             "accession": accession,
             "name": name,

--- a/pronto/api/entry/signatures.py
+++ b/pronto/api/entry/signatures.py
@@ -352,8 +352,8 @@ def get_signatures_annotations(accession):
     for accession, name, text in cur:
         #format citations coming from signatures
         if text and re.search(r'PMID', text):
-            REGEX_REPLACEMENTS = [(r']',']]'),('PMID: ','[cite:'),(r', \[', '], [')]
-            for old, new in REGEX_REPLACEMENTS:
+            regex_replacements = [(r']',']]'),('PMID:\s*','[cite:'),(r', \[', '], [')]
+            for old, new in regex_replacements:
                 text=re.sub(old, new, text)
         signatures.append({
             "accession": accession,


### PR DESCRIPTION
Curators have suggested it would be nice to have pre-formatted PMID for annotations coming from member databases.
E.g. for cdd: IPR001865, for Pfam: IPR000832 

I think it would be nice to apply the changes directly in the database, this way the annotations shown on the signatures pages will also be formatted and we could add a Reference section?