### PR TITLE
display GO taxon constraint table in entry page

### DIFF
--- a/pronto/templates/entry.html
+++ b/pronto/templates/entry.html
@@ -409,6 +409,14 @@ A second paragraph after an empty line.
     </div>
 </div>
 
+<div id="goconstraint-modal" class="ui modal">
+    <i class="close icon"></i>
+    <div class="ui header"></div>
+    <div class="scrolling content">
+        <ul class="ui list"></ul>
+    </div>
+</div>
+
 <script src="{{ url_for('static', filename='vendor/jquery.min.js') }}"></script>
 <script src="{{ url_for('static', filename='vendor/semantic.js') }}"></script>
 <script src="{{ url_for('static', filename='js/entry/entry.js') }}" type="module"></script>


### PR DESCRIPTION
This PR displays a GO taxon constraint table in InterPro entry pages when clicking on the taxon constraint red label.
The table shows the Taxon, type of constraint and number of proteins with the taxon and the total number of protein matches. The counters exclude fragment proteins.

Example of entries with GO terms having a taxon constraint:
IPR003705
IPR003488 (a lot of proteins)
IPR000354