### PR TITLE
[IBU-10646] Add AI-generated signature descriptions in Pronto database

### DIFF
--- a/pronto/api/entry/signatures.py
+++ b/pronto/api/entry/signatures.py
@@ -366,7 +366,7 @@ def get_signatures_annotations(accession):
     cur = con.cursor()
     cur.execute(
         f"""
-        SELECT accession, name, abstract, llm_summary
+        SELECT accession, name, abstract, llm_abstract
         FROM interpro.signature
         WHERE accession IN ({','.join('%s' for _ in signatures)})
         ORDER BY accession
@@ -375,12 +375,12 @@ def get_signatures_annotations(accession):
     )
 
     signatures = []
-    for accession, name, abstract, llm_summary in cur.fetchall():
-        if abstract:
+    for accession, name, abstract, llm_abstract in cur.fetchall():
+        if abstract or llm_abstract is None:
             text = abstract
             llm_generated = False
         else:
-            text = llm_summary
+            text = llm_abstract
             llm_generated = True
 
         signatures.append({

--- a/pronto/api/entry/signatures.py
+++ b/pronto/api/entry/signatures.py
@@ -376,18 +376,11 @@ def get_signatures_annotations(accession):
 
     signatures = []
     for accession, name, abstract, llm_abstract in cur.fetchall():
-        if abstract or llm_abstract is None:
-            text = abstract
-            llm_generated = False
-        else:
-            text = llm_abstract
-            llm_generated = True
-
         signatures.append({
             "accession": accession,
             "name": name,
-            "text": text,
-            "llm_generated": llm_generated
+            "text": abstract,
+            "llm_text": llm_abstract
         })
 
     cur.close()

--- a/pronto/api/entry/signatures.py
+++ b/pronto/api/entry/signatures.py
@@ -366,7 +366,7 @@ def get_signatures_annotations(accession):
     cur = con.cursor()
     cur.execute(
         f"""
-        SELECT accession, name, abstract
+        SELECT accession, name, abstract, llm_summary
         FROM interpro.signature
         WHERE accession IN ({','.join('%s' for _ in signatures)})
         ORDER BY accession
@@ -375,11 +375,19 @@ def get_signatures_annotations(accession):
     )
 
     signatures = []
-    for accession, name, text in cur.fetchall():
+    for accession, name, abstract, llm_summary in cur.fetchall():
+        if abstract:
+            text = abstract
+            llm_generated = False
+        else:
+            text = llm_summary
+            llm_generated = True
+
         signatures.append({
             "accession": accession,
             "name": name,
-            "text": text
+            "text": text,
+            "llm_generated": llm_generated
         })
 
     cur.close()

--- a/pronto/api/signature.py
+++ b/pronto/api/signature.py
@@ -21,7 +21,7 @@ def get_signature(accession):
           s.description,
           s.type,
           s.abstract,
-          s.llm_summary,
+          s.llm_abstract,
           s.num_sequences,
           s.num_complete_sequences,
           s.num_reviewed_sequences,
@@ -54,7 +54,7 @@ def get_signature(accession):
         "description": row[2],
         "type": row[3],
         "abstract": row[4],
-        "llm_summary": row[5],
+        "llm_abstract": row[5],
         "proteins": {
             "total": row[6],
             "complete": row[7],

--- a/pronto/api/signature.py
+++ b/pronto/api/signature.py
@@ -21,6 +21,7 @@ def get_signature(accession):
           s.description,
           s.type,
           s.abstract,
+          s.llm_summary,
           s.num_sequences,
           s.num_complete_sequences,
           s.num_reviewed_sequences,
@@ -53,20 +54,21 @@ def get_signature(accession):
         "description": row[2],
         "type": row[3],
         "abstract": row[4],
+        "llm_summary": row[5],
         "proteins": {
-            "total": row[5],
-            "complete": row[6],
+            "total": row[6],
+            "complete": row[7],
             "reviewed": {
-                "total": row[7],
-                "complete": row[8]
+                "total": row[8],
+                "complete": row[9]
             }
         },
         "database": {
-            "name": row[10],
+            "name": row[11],
             "home": db.home,
             "link": db.gen_link(accession),
             "color": db.color,
-            "version": row[11]
+            "version": row[12]
         },
         "entry": None
     }
@@ -299,7 +301,7 @@ def get_panther_go_subfam(accession, term_id):
 
     pg_con = utils.connect_pg()
     with pg_con.cursor() as pg_cur:
-    
+
         sql = """
             SELECT DISTINCT model_acc, protein_acc
             FROM interpro.signature2protein
@@ -339,7 +341,7 @@ def get_panther_go_subfam(accession, term_id):
         "count": count_prot,
         "results": results
     })
-    
+
 
 @bp.route("/<accession>/predictions/")
 def get_signature_predictions(accession):

--- a/pronto/api/signature.py
+++ b/pronto/api/signature.py
@@ -47,7 +47,7 @@ def get_signature(accession):
             }
         }), 404
 
-    db = utils.get_database_obj(row[9])
+    db = utils.get_database_obj(row[10])
     result = {
         "accession": row[0],
         "name": row[1],

--- a/pronto/static/js/entry/annotations.js
+++ b/pronto/static/js/entry/annotations.js
@@ -133,10 +133,8 @@ export function getSignaturesAnnotations(accession) {
                                     <p>${escape(signature.llm_text)}</p>
                                 </div>
                             `;
-                        }
-                        else
-                            html += '<div class="ui bottom attached secondary segment">No annotation.</div>';
-                    }
+                    } else
+                        html += '<div class="ui bottom attached secondary segment">No annotation.</div>';
                 }
             } else
                 html += `<p><strong>${accession}</strong> has no signatures.</p>`;

--- a/pronto/static/js/entry/annotations.js
+++ b/pronto/static/js/entry/annotations.js
@@ -101,7 +101,11 @@ export function getSignaturesAnnotations(accession) {
             let html = '';
             if (signatures.length > 0) {
                 for (const signature of signatures) {
-                    html += `<div class="ui top attached mini menu">`;
+                    if (signature.llm_generated == true)
+                       html += `<div class="ui top attached mini menu" style="background-color:#fff3d9;">`;
+                    else
+                        html += `<div class="ui top attached mini menu">`;
+
 
                     html += `<a class="header item" href="/signature/${signature.accession}/">${signature.accession}</a>`;
 
@@ -109,14 +113,17 @@ export function getSignaturesAnnotations(accession) {
                         html += `<span class="item">${signature.name}</span>`;
 
                     if (signature.llm_generated == true)
-                        html += `<span class="header item"><i class="attention red icon"></i>LLM generated</span>`;
+                        html += `<span class="header right item"><i class="attention red icon"></i>LLM generated</span>`;
 
                     html += '</div>';
 
                     if (signature.text !== null) {
                         signatureAnnotations.set(signature.accession, signature.text);
 
-                        html += `<div class="ui attached segment">`;
+                        if (signature.llm_generated == true)
+                            html += `<div class="ui attached segment" style="background-color:#fff3d9;">`;
+                        else
+                            html += `<div class="ui attached segment">`;
 
                         html += `
                             ${escape(signature.text)}

--- a/pronto/static/js/entry/annotations.js
+++ b/pronto/static/js/entry/annotations.js
@@ -124,8 +124,7 @@ export function getSignaturesAnnotations(accession) {
                                 </div>
                             </div>
                         `;
-                    } else {
-                        if (signature.llm_text !== null) {
+                    } else if (signature.llm_text !== null) {
                             html += `
                                 <div class="ui attached segment">
                                     <div class="ui warning message">

--- a/pronto/static/js/entry/annotations.js
+++ b/pronto/static/js/entry/annotations.js
@@ -130,8 +130,8 @@ export function getSignaturesAnnotations(accession) {
                                 <div class="ui attached segment">
                                     <div class="ui warning message">
                                         <div class="header"><i class="attention red icon"></i>LLM generated</div><p></p>
-                                        ${escape(signature.llm_text)}
                                     </div>
+                                    <p>${escape(signature.llm_text)}</p>
                                 </div>
                             `;
                         }

--- a/pronto/static/js/entry/annotations.js
+++ b/pronto/static/js/entry/annotations.js
@@ -109,6 +109,10 @@ export function getSignaturesAnnotations(accession) {
                     if (signature.name !== null)
                         html += `<span class="item">${signature.name}</span>`;
 
+                    if (signature.llm_generated == true)
+                            html += `<p style="color:#FF0000";><strong>LLM generated</strong></p>`;
+
+
                     html += '</div>';
 
                     if (signature.text !== null) {
@@ -183,7 +187,7 @@ export function refresh(accession) {
 
                         return `<a data-ref href="#${pubID}">${i}</a>`
                     }
-                    
+
                     return match;
                 });
 
@@ -223,7 +227,7 @@ export function refresh(accession) {
                                 <div class="item"><a data-action="save" class="ui primary button">Save</a></div>
                             </div>
                         </div>
-                        </div>  
+                        </div>
                     `;
                 }
             }
@@ -455,9 +459,9 @@ const annotationEditor = {
         text = text.replaceAll(rePub, (match, pubID) => {
             if (references.has(pubID)) {
                 const pub = references.get(pubID);
-                return `[cite:${pub.pmid}]`    
+                return `[cite:${pub.pmid}]`
             }
-            
+
             return match;
         });
 

--- a/pronto/static/js/entry/annotations.js
+++ b/pronto/static/js/entry/annotations.js
@@ -128,7 +128,9 @@ export function getSignaturesAnnotations(accession) {
                             html += `
                                 <div class="ui attached segment">
                                     <div class="ui warning message">
-                                        <div class="header"><i class="attention red icon"></i>LLM generated</div><p></p>
+                                    <div class="header">AI-generated annotation</div>
+                                    This annotation has been automatically generated using an AI language model.
+                                    Currently, importing AI-generated annotations for InterPro entries is not supported.
                                     </div>
                                     <p>${escape(signature.llm_text)}</p>
                                 </div>

--- a/pronto/static/js/entry/annotations.js
+++ b/pronto/static/js/entry/annotations.js
@@ -101,33 +101,38 @@ export function getSignaturesAnnotations(accession) {
             let html = '';
             if (signatures.length > 0) {
                 for (const signature of signatures) {
-                    html += `
-                            <div class="ui top attached mini menu">
-                            <a class="header item" href="/signature/${signature.accession}/">${signature.accession}</a>
-                        `;
+                    html += `<div class="ui top attached mini menu">`;
+
+                    html += `<a class="header item" href="/signature/${signature.accession}/">${signature.accession}</a>`;
 
                     if (signature.name !== null)
                         html += `<span class="item">${signature.name}</span>`;
 
                     if (signature.llm_generated == true)
-                            html += `<p style="color:#FF0000";><strong>LLM generated</strong></p>`;
-
+                        html += `<span class="header item"><i class="attention red icon"></i>LLM generated</span>`;
 
                     html += '</div>';
 
                     if (signature.text !== null) {
                         signatureAnnotations.set(signature.accession, signature.text);
+
+                        html += `<div class="ui attached segment">`;
+
                         html += `
-                            <div class="ui attached segment">
                             ${escape(signature.text)}
                             </div>
-                            <div class="ui bottom attached borderless mini menu">
-                                <span class="item message"></span>
-                                <div class="right item">
-                                <button data-id="${signature.accession}" class="ui primary button">Use</button>
-                                </div>
-                            </div>
                         `;
+
+                        if (signature.llm_generated == false) {
+                            html += `
+                                <div class="ui bottom attached borderless mini menu">
+                                    <span class="item message"></span>
+                                    <div class="right item">
+                                    <button data-id="${signature.accession}" class="ui primary button">Use</button>
+                                    </div>
+                                </div>
+                            `;
+                        }
                     } else
                         html += '<div class="ui bottom attached secondary segment">No annotation.</div>';
                 }

--- a/pronto/static/js/entry/annotations.js
+++ b/pronto/static/js/entry/annotations.js
@@ -101,47 +101,43 @@ export function getSignaturesAnnotations(accession) {
             let html = '';
             if (signatures.length > 0) {
                 for (const signature of signatures) {
-                    if (signature.llm_generated == true)
-                       html += `<div class="ui top attached mini menu" style="background-color:#fff3d9;">`;
-                    else
-                        html += `<div class="ui top attached mini menu">`;
-
-
-                    html += `<a class="header item" href="/signature/${signature.accession}/">${signature.accession}</a>`;
+                    html += `
+                            <div class="ui top attached mini menu">
+                            <a class="header item" href="/signature/${signature.accession}/">${signature.accession}</a>
+                        `;
 
                     if (signature.name !== null)
                         html += `<span class="item">${signature.name}</span>`;
-
-                    if (signature.llm_generated == true)
-                        html += `<span class="header right item"><i class="attention red icon"></i>LLM generated</span>`;
 
                     html += '</div>';
 
                     if (signature.text !== null) {
                         signatureAnnotations.set(signature.accession, signature.text);
-
-                        if (signature.llm_generated == true)
-                            html += `<div class="ui attached segment" style="background-color:#fff3d9;">`;
-                        else
-                            html += `<div class="ui attached segment">`;
-
                         html += `
+                            <div class="ui attached segment">
                             ${escape(signature.text)}
                             </div>
+                            <div class="ui bottom attached borderless mini menu">
+                                <span class="item message"></span>
+                                <div class="right item">
+                                <button data-id="${signature.accession}" class="ui primary button">Use</button>
+                                </div>
+                            </div>
                         `;
-
-                        if (signature.llm_generated == false) {
+                    } else {
+                        if (signature.llm_text !== null) {
                             html += `
-                                <div class="ui bottom attached borderless mini menu">
-                                    <span class="item message"></span>
-                                    <div class="right item">
-                                    <button data-id="${signature.accession}" class="ui primary button">Use</button>
+                                <div class="ui attached segment">
+                                    <div class="ui warning message">
+                                        <div class="header"><i class="attention red icon"></i>LLM generated</div><p></p>
+                                        ${escape(signature.llm_text)}
                                     </div>
                                 </div>
                             `;
                         }
-                    } else
-                        html += '<div class="ui bottom attached secondary segment">No annotation.</div>';
+                        else
+                            html += '<div class="ui bottom attached secondary segment">No annotation.</div>';
+                    }
                 }
             } else
                 html += `<p><strong>${accession}</strong> has no signatures.</p>`;


### PR DESCRIPTION
Show AI-generated descriptions when clicking "Signatures annotations" on an entry page. [Jira Ticket](https://www.ebi.ac.uk/panda/jira/browse/IBU-10646)

PS: testing on IPTST and inttst

Associated with [pyinterprod PR](https://github.com/ProteinsWebTeam/pyinterprod/pull/35).

