### PR TITLE
adding funfam GO terms

### DIFF
--- a/pronto/api/signature.py
+++ b/pronto/api/signature.py
@@ -303,7 +303,13 @@ def get_signature_go_info(accession, term_id):
     elif accession.startswith("G3DSA"):
         return get_funfam_go(accession, term_id)
     else:
-        return jsonify(), 404
+        return jsonify({
+            "error": {
+                "title": "Invalid signature",
+                "message": "Only CATH-Gene3D and PANTHER signatures "
+                           "have subfamilies."
+            }
+        }), 400
 
 def get_panther_go_subfam(accession, term_id):
 

--- a/pronto/api/signature.py
+++ b/pronto/api/signature.py
@@ -355,7 +355,7 @@ def get_funfam_go(accession, term_id):
     with pg_con.cursor() as pg_cur:
 
         sql = """
-            SELECT count(DISTINCT protein_acc)
+            SELECT count(protein_acc)
             FROM interpro.signature2protein
             WHERE signature_acc = %s
         """

--- a/pronto/api/signature.py
+++ b/pronto/api/signature.py
@@ -378,7 +378,7 @@ def get_funfam_go(accession, term_id):
         (str(f"{accession}%"), term_id)
     )
 
-    results = {acc: count for acc, count in cur.fetchall()}
+    results = dict(cur.fetchall())
     cur.close()
     con.close()
 

--- a/pronto/api/signature.py
+++ b/pronto/api/signature.py
@@ -4,7 +4,7 @@ from oracledb import DatabaseError
 from flask import Blueprint, jsonify, request
 
 from pronto import auth, utils
-import re
+
 
 bp = Blueprint("api_signature", __name__, url_prefix="/api/signature")
 
@@ -298,10 +298,12 @@ def get_term_citations(accession, term_id):
 
 @bp.route("/<accession>/go/<term_id>/subfam")
 def get_signature_go_info(accession, term_id):
-    if re.match('^PTHR', accession):
+    if accession.startswith("PTHR"):
         return get_panther_go_subfam(accession, term_id)
-    elif re.match('^G3DSA', accession):
+    elif accession.startswith("G3DSA"):
         return get_funfam_go(accession, term_id)
+    else:
+        return jsonify(), 404
 
 def get_panther_go_subfam(accession, term_id):
 

--- a/pronto/api/signature.py
+++ b/pronto/api/signature.py
@@ -370,7 +370,7 @@ def get_funfam_go(accession, term_id):
     cur.execute(
         f""" 
         SELECT METHOD_AC, count(PROTEIN_AC)
-        FROM FUNFAM2GO
+        FROM INTERPRO.FUNFAM2GO
         WHERE METHOD_AC LIKE :gene3d
           AND GO_ID = :go_id
         GROUP BY METHOD_AC

--- a/pronto/api/signature.py
+++ b/pronto/api/signature.py
@@ -375,7 +375,7 @@ def get_funfam_go(accession, term_id):
           AND GO_ID = :go_id
         GROUP BY METHOD_AC
         """,
-        (str(f"{accession}%"), term_id)
+        (f"{accession}%", term_id)
     )
 
     results = dict(cur.fetchall())

--- a/pronto/api/signature.py
+++ b/pronto/api/signature.py
@@ -311,6 +311,7 @@ def get_signature_go_info(accession, term_id):
             }
         }), 400
 
+
 def get_panther_go_subfam(accession, term_id):
 
     pg_con = utils.connect_pg()

--- a/pronto/api/signature.py
+++ b/pronto/api/signature.py
@@ -351,7 +351,7 @@ def get_panther_go_subfam(accession, term_id):
 
 def get_funfam_go(accession, term_id):
 
-    pg_con = pg_con = utils.connect_pg()
+    pg_con = utils.connect_pg()
     with pg_con.cursor() as pg_cur:
 
         sql = """

--- a/pronto/api/signatures/go.py
+++ b/pronto/api/signatures/go.py
@@ -84,7 +84,7 @@ def get_go_terms(accessions):
                 try:
                     g3d_signs[signature_acc].add(row[4])
                 except KeyError:
-                    g3d_signs[signature_acc] = set([row[4]])
+                    g3d_signs[signature_acc] = {row[4]}
 
         terms = get_go2panther(subfams, terms, cur)
 

--- a/pronto/api/signatures/go.py
+++ b/pronto/api/signatures/go.py
@@ -1,6 +1,5 @@
 from typing import Dict, List, Set
 from flask import jsonify, request
-import re
 
 from pronto import utils
 from . import bp, get_sig2interpro
@@ -80,7 +79,7 @@ def get_go_terms(accessions):
 
             if row[7] is not None:
                 subfams.add(row[7])
-            if re.match(r"G3DSA", signature_acc):
+            elif signature_acc.startswith("G3DSA"):
                 try:
                     g3d_signs[signature_acc].add(row[4])
                 except KeyError:
@@ -168,12 +167,11 @@ def get_go2funfam(gene3dset: dict, terms: dict, pg_cur):
     go_terms = set()
 
     for signature, proteins in gene3dset.items():
-        signlike = f"{signature}%"
 
         for i in range(0, len(proteins), 1000):
             subset = list(proteins)[i:i+1000]
             binds = [":" + str(j+1) for j in range(len(subset))]
-            subset.append(str(signlike))
+            subset.append(f"{signature}%")
 
             request = f"""
             SELECT DISTINCT METHOD_AC, GO_ID
@@ -199,7 +197,6 @@ def get_go2funfam(gene3dset: dict, terms: dict, pg_cur):
                     s = term["signatures"][signature] = [set(), set(), set()]
 
                 s[2].add(row[0])
-                s[0].update(set(subset))
 
     cur.close()
     con.close()

--- a/pronto/static/js/signatures/go.js
+++ b/pronto/static/js/signatures/go.js
@@ -186,7 +186,7 @@ function getGoTerms(accessions) {
 
                             for (const subfam in object.results) {
                                 html += `<tr>`;
-                                if (acc.search('PTHR') == 0) {
+                                if (acc.startsWith('PTHR')) {
                                     html += `<td>
                                     <a target="_blank" href="//www.pantherdb.org/panther/family.do?clsAccession=${subfam}">${subfam}<i class="external icon"></i></a>
                                     </td>`;

--- a/pronto/static/js/signatures/go.js
+++ b/pronto/static/js/signatures/go.js
@@ -209,7 +209,7 @@ function getGoTerms(accessions) {
                                     </table>`;
 
                             const modal = document.getElementById('signature-modal');
-                            if (acc.search('PTHR') == 0) {
+                            if (acc.startsWith('PTHR')) {
                                 modal.querySelector('.ui.header').innerHTML = `PANTHER subfamilies: ${acc}/${term}`;
                             }
                             else if (acc.search('G3DSA') == 0) {

--- a/pronto/static/js/signatures/go.js
+++ b/pronto/static/js/signatures/go.js
@@ -192,11 +192,8 @@ function getGoTerms(accessions) {
                                     </td>`;
                                 }
                                 else if (acc.startsWith('G3DSA')) {
-                                    console.log(subfam);
-                                    const fam = subfam.split(':')[1];
-                                    const funfam = subfam.split(':')[3].replace(/^0+/, '');
-                                    console.log(funfam);
-                                    html += `<td><a target="_blank" href="//www.cathdb.info/version/v4_3_0/superfamily/${fam}/funfam/${funfam}">${subfam}<i class="external icon"></i></a></td>`
+                                    const [_, famId, funfamId] = subfam.match(/G3DSA:([0-9.]+):FF:(\d+)/);
+                                    html += `<td><a target="_blank" href="//www.cathdb.info/version/v4_3_0/superfamily/${famId}/funfam/${Number.parseInt(funfamId, 10)}">${subfam}<i class="external icon"></i></a></td>`;
                                 }
 
                                 html += `

--- a/pronto/static/js/signatures/go.js
+++ b/pronto/static/js/signatures/go.js
@@ -212,7 +212,7 @@ function getGoTerms(accessions) {
                             if (acc.startsWith('PTHR')) {
                                 modal.querySelector('.ui.header').innerHTML = `PANTHER subfamilies: ${acc}/${term}`;
                             }
-                            else if (acc.search('G3DSA') == 0) {
+                            else if (acc.startsWith('G3DSA')) {
                                 modal.querySelector('.ui.header').innerHTML = `CATH-Gene3D Funfams: ${acc}/${term}`;
                             }
                             modal.querySelector('.content ul').innerHTML = html;

--- a/pronto/static/js/signatures/go.js
+++ b/pronto/static/js/signatures/go.js
@@ -191,7 +191,7 @@ function getGoTerms(accessions) {
                                     <a target="_blank" href="//www.pantherdb.org/panther/family.do?clsAccession=${subfam}">${subfam}<i class="external icon"></i></a>
                                     </td>`;
                                 }
-                                else if (acc.search('G3DSA') == 0) {
+                                else if (acc.startsWith('G3DSA')) {
                                     console.log(subfam);
                                     const fam = subfam.split(':')[1];
                                     const funfam = subfam.split(':')[3].replace(/^0+/, '');

--- a/pronto/static/js/signatures/go.js
+++ b/pronto/static/js/signatures/go.js
@@ -21,10 +21,10 @@ function getGoTerms(accessions) {
         .then(response => response.json())
         .then((data,) => {
             const sig2ipr = new Map(Object.entries(data.integrated));
-            const isPanther = new RegExp('^PTHR');
+            const signWithGO = new RegExp('^(PTHR|G3DSA)');
 
             const genCell = (acc,) => {
-                const span = isPanther.test(acc) ? 3 : 2;
+                const span = signWithGO.test(acc) ? 3 : 2;
                 if (sig2ipr.has(acc))
                     return `<th class="center aligned" colspan="${span}"><span data-tooltip="${sig2ipr.get(acc)}" data-inverted=""><i class="star icon"></i>${acc}</span></th>`;
                 else
@@ -43,8 +43,8 @@ function getGoTerms(accessions) {
                 html += `
                         <th class="collapsing center aligned normal">UNI</th>
                         <th class="collapsing center aligned">REF</th>`;
-                if (isPanther.test(accessions[i]))
-                    html += `<th class="collapsing center aligned">PTHR</th>`;
+                if (signWithGO.test(accessions[i]))
+                    html += `<th class="collapsing center aligned">SIGN</th>`;
 
             }
             html += `</tr></thead>`;
@@ -80,17 +80,17 @@ function getGoTerms(accessions) {
                         } else
                             html += '<td class="collapsing"></td>';
 
-                        if (signature.panthergo > 0) {
+                        if (signature.signaturego > 0) {
                             html += `<td class="collapsing center aligned">
-                                        <a href="#!" data-signature="${acc}" data-term="${term.id}" data-panther="">${signature.panthergo.toLocaleString()}</a>
+                                        <a href="#!" data-signature="${acc}" data-term="${term.id}" data-sign="">${signature.signaturego.toLocaleString()}</a>
                                      </td>`;
-                        } else if (isPanther.test(acc))
+                        } else if (signWithGO.test(acc))
                             html += '<td class="collapsing"></td>';
 
                     } else {
                         html += '<td class="collapsing"></td><td class="collapsing"></td>';
 
-                        if (isPanther.test(acc)) {
+                        if (signWithGO.test(acc)) {
                             html += '<td class="collapsing"></td>';
                         }
                     }
@@ -105,7 +105,7 @@ function getGoTerms(accessions) {
                 input.checked = data.aspects.includes(input.value);
             }
 
-            for (const elem of table.querySelectorAll('[data-signature]:not(.label):not([data-panther])')) {
+            for (const elem of table.querySelectorAll('[data-signature]:not(.label):not([data-sign])')) {
                 elem.addEventListener('click', e => {
                     const acc = e.currentTarget.dataset.signature;
                     const termID = e.currentTarget.dataset.term;
@@ -162,8 +162,8 @@ function getGoTerms(accessions) {
                 });
             }
 
-            // Get PANTHER subfamilies references
-            for (const elem of table.querySelectorAll('[data-signature][data-panther]')) {
+            // Get PANTHER subfamilies or funfam info
+            for (const elem of table.querySelectorAll('[data-signature][data-sign]')) {
                 elem.addEventListener('click', (e,) => {
                     const acc = e.currentTarget.dataset.signature;
                     const term = e.currentTarget.dataset.term;
@@ -185,10 +185,21 @@ function getGoTerms(accessions) {
                                         <tbody>`;
 
                             for (const subfam in object.results) {
-                                html += `<tr>
-                                            <td>
-                                            <a target="_blank" href="//www.pantherdb.org/panther/family.do?clsAccession=${subfam}">${subfam}<i class="external icon"></i></a>
-                                            </td>
+                                html += `<tr>`;
+                                if (acc.search('PTHR') == 0) {
+                                    html += `<td>
+                                    <a target="_blank" href="//www.pantherdb.org/panther/family.do?clsAccession=${subfam}">${subfam}<i class="external icon"></i></a>
+                                    </td>`;
+                                }
+                                else if (acc.search('G3DSA') == 0) {
+                                    console.log(subfam);
+                                    const fam = subfam.split(':')[1];
+                                    const funfam = subfam.split(':')[3].replace(/^0+/, '');
+                                    console.log(funfam);
+                                    html += `<td><a target="_blank" href="//www.cathdb.info/version/v4_3_0/superfamily/${fam}/funfam/${funfam}">${subfam}<i class="external icon"></i></a></td>`
+                                }
+
+                                html += `
                                             <td>${object.results[subfam].toLocaleString()}</td>
                                             <td>${object.count.toLocaleString()}</td>
                                          </tr>`;
@@ -197,8 +208,13 @@ function getGoTerms(accessions) {
                             html += `</tbody>
                                     </table>`;
 
-                            const modal = document.getElementById('panther-modal');
-                            modal.querySelector('.ui.header').innerHTML = `PANTHER subfamilies: ${acc}/${term}`;
+                            const modal = document.getElementById('signature-modal');
+                            if (acc.search('PTHR') == 0) {
+                                modal.querySelector('.ui.header').innerHTML = `PANTHER subfamilies: ${acc}/${term}`;
+                            }
+                            else if (acc.search('G3DSA') == 0) {
+                                modal.querySelector('.ui.header').innerHTML = `CATH-Gene3D Funfams: ${acc}/${term}`;
+                            }
                             modal.querySelector('.content ul').innerHTML = html;
                             modal.querySelector('.actions a').setAttribute('href', `//www.ebi.ac.uk/QuickGO/term/${term}`);
                             $(modal).modal('show');
@@ -207,8 +223,6 @@ function getGoTerms(accessions) {
 
                 });
             }
-
-
 
             dimmer.off();
         });

--- a/pronto/templates/signatures/go.html
+++ b/pronto/templates/signatures/go.html
@@ -65,7 +65,7 @@
     </div>
 </div>
 
-<div id="panther-modal" class="ui modal">
+<div id="signature-modal" class="ui modal">
     <i class="close icon"></i>
     <div class="ui header"></div>
     <div class="scrolling content">


### PR DESCRIPTION
This is the PR to add Funfam GO terms to the GO terms tab in Pronto.
When clicking on the number, I've tried to reuse the module created for PANTHER GO terms, let me know if you think it would be better to separate the 2 completely.

Example of a small Gene3D entry: http://127.0.0.1:5000/signatures/G3DSA:1.10.10.1210/go/#!
And a big one: http://127.0.0.1:5000/signatures/G3DSA:3.20.20.70/go/#!