### PR TITLE
Add GO term constraint information on Entry pages front-end

### DIFF
--- a/pronto/static/css/go.css
+++ b/pronto/static/css/go.css
@@ -13,9 +13,3 @@
     border-color: #FF9E80;
     color: #fff;
 }
-.ui.table>thead>tr>th.normal {
-    border-left: 1px solid rgba(34, 36, 38, 0.1) !important;
-    background: #F9FAFB !important;
-    color: rgba(0, 0, 0, 0.87) !important;
-    font-weight: bold !important;
-}

--- a/pronto/static/css/main.css
+++ b/pronto/static/css/main.css
@@ -90,6 +90,12 @@ code.negative {
     font-weight: normal;
 }
 
+.ui.table>thead>tr>th.normal {
+    border-left: 1px solid rgba(34, 36, 38, 0.1) !important;
+    background: #F9FAFB !important;
+    color: rgba(0, 0, 0, 0.87) !important;
+    font-weight: bold !important;
+}
 /* Toggle checkbox */
 .ui.toggle.checkbox + .ui.toggle.checkbox {
     margin-left: 2em;

--- a/pronto/static/js/entry/go.js
+++ b/pronto/static/js/entry/go.js
@@ -112,7 +112,7 @@ function render(accession, terms, divID) {
                             </table>`;
 
                     const modal = document.getElementById('goconstraint-modal');
-                    modal.querySelector('.ui.header').innerHTML = `GO constraint: ${term}`;
+                    modal.querySelector('.ui.header').innerHTML = `GO constraints: ${term}`;
                     modal.querySelector('.scrolling.content').innerHTML = html;
                     $(modal).modal('show');
                     dimmer.off();

--- a/pronto/static/js/entry/go.js
+++ b/pronto/static/js/entry/go.js
@@ -82,7 +82,7 @@ function render(accession, terms, divID) {
             fetch(`/api/entry/${acc}/go/${term}/`, { method: 'GET' })
                 .then(response => response.json())
                 .then(result => {
-                    const signatures = result.signatures.toString().replace(/,/g, '/');
+                    const signatures = result.signatures.join('/');
                     let html = `<table class="ui definition celled table">
                                     <thead>
                                         <tr>

--- a/pronto/static/js/entry/go.js
+++ b/pronto/static/js/entry/go.js
@@ -87,28 +87,24 @@ function render(accession, terms, divID) {
                                     <thead>
                                         <tr>
                                             <th class="normal">Taxon constraint</th>
-                                            <th>Swiss-Prot/reviewed proteins - ${result.proteins.reviewed}</th>
-                                            <th>All proteins - ${result.proteins.total}</th>
+                                            <th>Swiss-Prot/reviewed proteins - ${result.proteins.reviewed.toLocaleString()}</th>
+                                            <th>All proteins - ${result.proteins.total.toLocaleString()}</th>
                                         </tr>
                                     </thead>
                                     <tbody>
 
                                     <tr>
                                     <td>Violations summary</td>
-                                    <td><a href="/signatures/${signatures}/proteins/?violate-go=${term}&reviewed">${result.violations.reviewed}</a></td>
-                                    <td><a href="/signatures/${signatures}/proteins/?violate-go=${term}">${result.violations.total}</a></td>
+                                    <td><a href="/signatures/${signatures}/proteins/?violate-go=${term}&reviewed">${result.violations.reviewed.toLocaleString()}</a></td>
+                                    <td><a href="/signatures/${signatures}/proteins/?violate-go=${term}">${result.violations.total.toLocaleString()}</a></td>
                                     </tr>`;
 
                     for (const item in result.constraint) {
-
-                        let constType = result.constraint[item].type;
-                        constType = constType.replace(/only_in_taxon/g, 'Only in');
-                        constType = constType.replace(/never_in_taxon/g, 'Never in');
-
+                        const constType = result.constraint[item].type === 'only_in_taxon' ? 'Only in' : 'Never in';
                         html += `<tr>
                                 <td>${constType} ${result.constraint[item].taxon.name}</td>
-                                <td>${result.constraint[item].matches.reviewed}</td>
-                                <td>${result.constraint[item].matches.total}</td>
+                                <td>${result.constraint[item].matches.reviewed.toLocaleString()}</td>
+                                <td>${result.constraint[item].matches.total.toLocaleString()}</td>
                                 </tr>`;
                     }
 

--- a/pronto/static/js/entry/go.js
+++ b/pronto/static/js/entry/go.js
@@ -73,7 +73,7 @@ function render(accession, terms, divID) {
         });
     }
 
-    for (const elem of document.querySelectorAll('[data-entry]')) {
+    for (const elem of div.querySelectorAll('[data-entry]')) {
         elem.addEventListener('click', (e,) => {
             const acc = e.currentTarget.dataset.entry;
             const term = e.currentTarget.dataset.term;

--- a/pronto/static/js/entry/go.js
+++ b/pronto/static/js/entry/go.js
@@ -99,12 +99,12 @@ function render(accession, terms, divID) {
                                     <td><a href="/signatures/${signatures}/proteins/?violate-go=${term}">${result.violations.total.toLocaleString()}</a></td>
                                     </tr>`;
 
-                    for (const item in result.constraint) {
-                        const constType = result.constraint[item].type === 'only_in_taxon' ? 'Only in' : 'Never in';
+                    for (const constraint of result.constraint) {
+                        const constType = constraint.type === 'only_in_taxon' ? 'Only in' : 'Never in';
                         html += `<tr>
-                                <td>${constType} ${result.constraint[item].taxon.name}</td>
-                                <td>${result.constraint[item].matches.reviewed.toLocaleString()}</td>
-                                <td>${result.constraint[item].matches.total.toLocaleString()}</td>
+                                <td>${constType} ${constraint.taxon.name}</td>
+                                <td>${constraint.matches.reviewed.toLocaleString()}</td>
+                                <td>${constraint.matches.total.toLocaleString()}</td>
                                 </tr>`;
                     }
 

--- a/pronto/static/js/entry/go.js
+++ b/pronto/static/js/entry/go.js
@@ -79,7 +79,7 @@ function render(accession, terms, divID) {
             const term = e.currentTarget.dataset.term;
 
             dimmer.on();
-            fetch(`/api/entry/${acc}/go/${term}/`, { method: 'GET' })
+            fetch(`/api/entry/${acc}/go/${term}/`)
                 .then(response => response.json())
                 .then(result => {
                     const signatures = result.signatures.join('/');

--- a/pronto/static/js/signatures/go.js
+++ b/pronto/static/js/signatures/go.js
@@ -212,7 +212,7 @@ function getGoTerms(accessions) {
                             else if (acc.startsWith('G3DSA')) {
                                 modal.querySelector('.ui.header').innerHTML = `CATH-Gene3D Funfams: ${acc}/${term}`;
                             }
-                            modal.querySelector('.content ul').innerHTML = html;
+                            modal.querySelector('.scrolling.content').innerHTML = html;
                             modal.querySelector('.actions a').setAttribute('href', `//www.ebi.ac.uk/QuickGO/term/${term}`);
                             $(modal).modal('show');
                             dimmer.off();

--- a/pronto/templates/entry.html
+++ b/pronto/templates/entry.html
@@ -409,6 +409,12 @@ A second paragraph after an empty line.
     </div>
 </div>
 
+<div id="goconstraint-modal" class="ui modal">
+    <i class="close icon"></i>
+    <div class="ui header"></div>
+    <div class="scrolling content"></div>
+</div>
+
 <script src="{{ url_for('static', filename='vendor/jquery.min.js') }}"></script>
 <script src="{{ url_for('static', filename='vendor/semantic.js') }}"></script>
 <script src="{{ url_for('static', filename='js/entry/entry.js') }}" type="module"></script>

--- a/pronto/templates/signatures/go.html
+++ b/pronto/templates/signatures/go.html
@@ -68,9 +68,7 @@
 <div id="signature-modal" class="ui modal">
     <i class="close icon"></i>
     <div class="ui header"></div>
-    <div class="scrolling content">
-        <ul class="ui list"></ul>
-    </div>
+    <div class="scrolling content"></div>
     <div class="actions">
         <a target="_blank" href="" class="ui basic button">
             <i class="external icon"></i>


### PR DESCRIPTION
This PR displays a GO taxon constraint table in InterPro entry pages when clicking on the taxon constraint red label. The second row shows a summary of the proteins violating the constraint.
The table has 3 columns: 

1. Constraint type
2. number of proteins with the taxon for SwissProt proteins
3. number of proteins with the taxon for all the proteins

Example of entries with GO terms having a taxon constraint:
IPR003705
IPR003488 (a lot of proteins)
IPR000354