### PR TITLE
Add unique constraint check for proposed and entry names and short names

### DIFF
--- a/pronto/api/entry/__init__.py
+++ b/pronto/api/entry/__init__.py
@@ -1,6 +1,5 @@
 import re
 
-from typing import Tuple
 
 import oracledb
 from flask import Blueprint, jsonify, request

--- a/pronto/api/entry/__init__.py
+++ b/pronto/api/entry/__init__.py
@@ -447,10 +447,16 @@ def create_entry():
             }
         }), 400
 
-    response_dict, response_status = check_unique_constraints(entry_name, entry_short_name)
-    if response_status != 200:
-        return jsonify(response_dict), response_status
-
+    entries = check_uniqueness(entry_name, entry_short_name)
+    if entries:
+        return jsonify({
+            "status": False,
+            "error": {
+                "title": "Bad request",
+                "message": "The name or short name is already in use.",
+                "entries": entries
+            }
+        }), 400
     try:
         is_llm_reviewed = request.json["is_llm_reviewed"]
     except KeyError:


### PR DESCRIPTION
Instead of relying on the unique constraint check for name/short name when creating new entries, prior to attempt an insertion into the db, query the proposed entry's name and short name against the oracle db. Flag if the name/short name are already associated with an entry and terminate the creation of the proposed entry.