### PR TITLE
[IBU-10928] Add LLM filter to sanity check report table

### DIFF
--- a/pronto/static/js/index.js
+++ b/pronto/static/js/index.js
@@ -736,8 +736,13 @@ async function getSanityCheck() {
     let numUnresolved = 0;
     if (object.errors.length > 0) {
         let count = 0
+        const includeLlm = document.querySelector('input[name="include-llm"]').checked;
         for (const error of object.errors) {
             count += 1
+            // If 'include llm' checkbox is not checked and error.llm is true, skip this error
+            if (!includeLlm && error.llm) {
+                continue;
+            }
             const acc = error.annotation !== null ? error.annotation : error.entry;
             const iconClass = error.llm ? 'robot' : 'user';
             html += `
@@ -1119,7 +1124,7 @@ document.addEventListener('DOMContentLoaded', () => {
     updateHeader();
     backToTop();
     const match = location.href.match(/\/#\/(.+)$/);
-
+    
     // Init tabs
     $('.tabular.menu .item').tab({
         // If URL endswith /#/<tab> and <tab> exists in markup, select this tab, otherwise (true) select the first tab
@@ -1241,6 +1246,13 @@ document.addEventListener('DOMContentLoaded', () => {
                         plotJobTimeChart();
                         plotJobMemoryChart();
                     }, 1000);
-                });
+                });    sanityLlmCheckbox
         });
+
 });
+
+// reload sanity check records if 'show llms' checkbox is checked/unchecked
+document.querySelector('input[name="include-llm"]').addEventListener('change', function() {
+    getSanityCheck();
+});
+

--- a/pronto/static/js/index.js
+++ b/pronto/static/js/index.js
@@ -738,11 +738,13 @@ async function getSanityCheck() {
         let count = 0
         const includeLlm = document.querySelector('input[name="include-llm"]').checked;
         for (const error of object.errors) {
-            count += 1
             // If 'include llm' checkbox is not checked and error.llm is true, skip this error
             if (!includeLlm && error.llm) {
                 continue;
             }
+            
+            count += 1
+
             const acc = error.annotation !== null ? error.annotation : error.entry;
             const iconClass = error.llm ? 'robot' : 'user';
             html += `

--- a/pronto/static/js/index.js
+++ b/pronto/static/js/index.js
@@ -1246,7 +1246,7 @@ document.addEventListener('DOMContentLoaded', () => {
                         plotJobTimeChart();
                         plotJobMemoryChart();
                     }, 1000);
-                });    sanityLlmCheckbox
+                });
         });
 
 });

--- a/pronto/static/js/index.js
+++ b/pronto/static/js/index.js
@@ -1249,10 +1249,12 @@ document.addEventListener('DOMContentLoaded', () => {
                 });
         });
 
+    // reload sanity check records if 'show llms' checkbox is checked/unchecked
+    document
+        .querySelector('input[name="include-llm"]')
+        .addEventListener('change', () => {
+            dimmer.on();
+            getSanityCheck()
+                .then(() => {dimmer.off()})
+    }); 
 });
-
-// reload sanity check records if 'show llms' checkbox is checked/unchecked
-document.querySelector('input[name="include-llm"]').addEventListener('change', function() {
-    getSanityCheck();
-});
-

--- a/pronto/templates/index.html
+++ b/pronto/templates/index.html
@@ -116,15 +116,18 @@
                     </table>
                 </div>
                 <div class="ui tab basic segment" data-tab="checks">
-                    <div>
-                        <button class="ui compact primary button">Run</button>
-                        <a href="/checks/" class="ui compact basic button">Details</a>
-                    </div>
-                    
-                    <div class="ui checkbox", style="margin-top: 15px;">
-                        <input type="checkbox" name="include-llm">
-                        <label>Show errors for AI-generated entries and annotations</label>
-                    </div>                    
+                    <div class="ui form">
+                        <div class="fields">
+                            <button class="ui compact primary button">Run</button>
+                            <a href="/checks/" class="ui compact basic button">Details</a>
+                        </div>
+                        <div class="field">
+                            <div class="ui checkbox">
+                                <input type="checkbox" name="include-llm">
+                                <label>Show errors for AI-generated entries and annotations</label>
+                            </div>
+                        </div>
+                    </div>    
 
                     <div class="ui hidden message"></div>
                     <table class="ui single line compact table">

--- a/pronto/templates/index.html
+++ b/pronto/templates/index.html
@@ -116,8 +116,16 @@
                     </table>
                 </div>
                 <div class="ui tab basic segment" data-tab="checks">
-                    <button class="ui compact primary button">Run</button>
-                    <a href="/checks/" class="ui compact basic button">Details</a>
+                    <div>
+                        <button class="ui compact primary button">Run</button>
+                        <a href="/checks/" class="ui compact basic button">Details</a>
+                    </div>
+                    
+                    <div class="ui checkbox", style="margin-top: 15px;">
+                        <input type="checkbox" name="include-llm">
+                        <label>Show errors for AI-generated entries and annotations</label>
+                    </div>                    
+
                     <div class="ui hidden message"></div>
                     <table class="ui single line compact table">
                         <thead>


### PR DESCRIPTION
[Jira](https://www.ebi.ac.uk/panda/jira/browse/IBU-10928)

Currently, Pronto displays all errors. This PR allows curators to show/hide errors for LLM-generated entries and descriptions. 

Checkbox added to top of sanity check table, and checking/unchecking the box automatically reloads the table with the appropriate data.

Tested on `IPTST`.