### PR TITLE
resolve GO taxonomy constraint count issue

### DIFF
--- a/pronto/api/entry/go.py
+++ b/pronto/api/entry/go.py
@@ -258,7 +258,7 @@ def get_term_constraints(accession, term_id):
             if constraint["type"] == "never_in_taxon":
                 if left_num <= taxon_left_num <= right_num:
                     is_ok = False
-                else:
+
                     constraint["matches"]["total"] += 1
                     if is_reviewed:
                         constraint["matches"]["reviewed"] += 1

--- a/pronto/api/entry/go.py
+++ b/pronto/api/entry/go.py
@@ -258,7 +258,7 @@ def get_term_constraints(accession, term_id):
             if constraint["type"] == "never_in_taxon":
                 if left_num <= taxon_left_num <= right_num:
                     is_ok = False
-
+                else:
                     constraint["matches"]["total"] += 1
                     if is_reviewed:
                         constraint["matches"]["reviewed"] += 1

--- a/pronto/api/signatures/proteins.py
+++ b/pronto/api/signatures/proteins.py
@@ -190,12 +190,12 @@ def get_proteins_alt(accessions):
                 [violate_term_id]
             )
             for rel_type, left_num, right_num in cur.fetchall():
-                if rel_type == "only_in_taxon":
-                    only_in.append("taxon_left_num NOT BETWEEN %s AND %s")
-                    only_in_params += [left_num, right_num]
-                else:
+                if rel_type == "never_in_taxon":
                     tax_filters.append("taxon_left_num BETWEEN %s AND %s")
                     tax_params += [left_num, right_num]
+                else:
+                    only_in.append("taxon_left_num NOT BETWEEN %s AND %s")
+                    only_in_params += [left_num, right_num]
 
             if only_in:
                 tax_filters.append(f"({' AND '.join(only_in)})")

--- a/pronto/static/js/entry/go.js
+++ b/pronto/static/js/entry/go.js
@@ -100,7 +100,7 @@ function render(accession, terms, divID) {
                                     </tr>`;
 
                     for (const constraint of result.constraint) {
-                        const constType = constraint.type === 'in_taxon' ? 'Only in' : 'Never in';
+                        const constType = constraint.type === 'never_in_taxon' ? 'Never in' : 'Only in';
                         html += `<tr>
                                 <td>${constType} ${constraint.taxon.name}</td>
                                 <td>${constraint.matches.reviewed.toLocaleString()}</td>

--- a/pronto/static/js/entry/go.js
+++ b/pronto/static/js/entry/go.js
@@ -100,7 +100,7 @@ function render(accession, terms, divID) {
                                     </tr>`;
 
                     for (const constraint of result.constraint) {
-                        const constType = constraint.type === 'only_in_taxon' ? 'Only in' : 'Never in';
+                        const constType = constraint.type === 'in_taxon' ? 'Only in' : 'Never in';
                         html += `<tr>
                                 <td>${constType} ${constraint.taxon.name}</td>
                                 <td>${constraint.matches.reviewed.toLocaleString()}</td>


### PR DESCRIPTION
This PR resolves the following issues in the GO taxonomy constraint table:

- The GO constraint table was always showing "Never in ..." even when the taxonomy was "Only in ...".
- The counts should be 0 when no proteins are found in the taxonomy for "Never in ...", but it was showing the total number of proteins instead.