### PR TITLE
[IBU-11230] Fix InterProScan analysis runtime data retrieval

### DIFF
--- a/pronto/api/interproscan.py
+++ b/pronto/api/interproscan.py
@@ -112,6 +112,7 @@ def get_analysis(name: str, version: str):
           AND J.SUCCESS = 'Y'
           AND J.SEQUENCES IS NOT NULL
           AND J.SEQUENCES > 0
+          AND (J.CPU_TIME > 0 AND J.LIM_MEMORY IS NOT NULL)
         """,
         params
     )


### PR DESCRIPTION
[Jira](https://www.ebi.ac.uk/panda/jira/browse/IBU-11230)

Loading the InterProScan data in pronto (on the live and test serves) hangs at 35%, because of an error in the backend. Additionally, some API queries fail.

The issue is due to the INTERPRO.ISPRO_ANALYSIS (api/interproscan.py) query returning null/None values for the MAX_MEMORY for some analyses, typically these analyses also have 0 CPU_TIME.

This PR fixes the issue but updating the INTERPRO.ISPRO_ANALYSIS query so that it does not return queries with CPU_TIME of 0 and MAX_MEM of null - these rows appear to represent failed or cancelled runs and aren't informative to include when evaluating the computer resource usage of InterProScan.

Tested locally via a web browser and accessing the InterProScan tab (http://127.0.0.1:5000/#/interproscan) and via the API (http://127.0.0.1:5000/api/interproscan/PANTHER/19.0/?sequences=10000000)