### PR TITLE
Prevent integration of AMR models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ config.local.cfg
 .vscode
 *.egg-info
 build/
+.DS_Store

--- a/pronto/api/entry/signatures.py
+++ b/pronto/api/entry/signatures.py
@@ -2,6 +2,7 @@ from oracledb import Cursor, DatabaseError
 from flask import jsonify, request
 
 from pronto import auth, utils
+from pronto.api.signature import check_if_ncbifam_amr, ncbifam_amr_err_msg
 from . import bp
 
 
@@ -123,6 +124,9 @@ def integrate_signature(e_acc, s_acc):
                            f"not match any protein."
             }
         }), 400
+    
+    if check_if_ncbifam_amr(s_acc):
+        return jsonify(ncbifam_amr_err_msg(s_acc)), 400
 
     con = utils.connect_oracle_auth(user)
     cur = con.cursor()

--- a/pronto/api/signature.py
+++ b/pronto/api/signature.py
@@ -658,7 +658,7 @@ def check_if_ncbifam_amr(accession: str) -> bool:
     cur = con.cursor()
     cur.execute(
         f"""
-        SELECT *
+        SELECT COUNT(*)
         FROM INTERPRO.NCBIFAM_AMR
         WHERE METHOD_AC = :1
         """,
@@ -669,7 +669,7 @@ def check_if_ncbifam_amr(accession: str) -> bool:
     return cnt > 0
 
 
-def ncbifam_amr_err_msg(accession):
+def ncbifam_amr_err_msg(accession: str) -> dict:
     return {
         "status": False,
             "error": {

--- a/pronto/api/signature.py
+++ b/pronto/api/signature.py
@@ -48,7 +48,7 @@ def get_signature(accession):
         return jsonify({
             "error": {
                 "title": "Signature not found",
-                "message": f"<strong>{accession}</strong> does not match any member database signature accession or name."
+                "message": f"{accession} does not match any member database signature accession or name."
             }
         }), 404
     
@@ -652,7 +652,7 @@ class Sorter(object):
         return i, j, -obj["residues"][key], -obj[key]
 
 
-def check_if_ncbifam_amr(method_ac):
+def check_if_ncbifam_amr(accession: str) -> bool:
 
     con = utils.connect_oracle()
     cur = con.cursor()
@@ -660,16 +660,20 @@ def check_if_ncbifam_amr(method_ac):
         f"""
         SELECT *
         FROM INTERPRO.NCBIFAM_AMR
-        WHERE METHOD_AC = '{method_ac}'"""
+        WHERE METHOD_AC = :1
+        """,
+        [accession]
     )
 
-    return len(cur.fetchall()) > 0
+    cnt, = cur.fetchone()
+    return cnt > 0
+
 
 def ncbifam_amr_err_msg(accession):
     return {
         "status": False,
             "error": {
                 "title": "Can't integrate signature",
-                "message": f"<strong>{accession}</strong> is an NCBIfam AMR model."
+                "message": f"{accession} is an NCBIfam AMR model."
             }
         }

--- a/pronto/static/js/ui/header.js
+++ b/pronto/static/js/ui/header.js
@@ -110,13 +110,14 @@ export function updateHeader(signatureAcc) {
                         const acc = fields.accession.trim();
                         fetch(`/api/signature/${acc}/`)
                             .then(response => {
-                                if (!response.ok)
-                                    throw new Error(
-                                        'Signature not found',
-                                        {
-                                            cause: `<strong>${acc}</strong> does not match any member database signature accession or name.`
-                                        }
-                                    );
+                                if (!response.ok) {
+
+                                    return response.json().then(errorData => {
+                                        throw new Error(errorData.error.title, {
+                                            cause: errorData.error.message,
+                                        });
+                                    });
+                                }
                                 return response.json();
                             })
                             .then(signature => {


### PR DESCRIPTION
This PR addresses [IBU-11583](https://www.ebi.ac.uk/panda/jira/browse/IBU-11583).

- Integration of NCBIFam accessions that are found in the NCBIFAM_AMR table is now forbidden for new entries/existing ones;
- The only frontend change needed was to generalize the request error handling (404 when a signature is not found, 400 in this case)