### PR TITLE
Accessibility update

### DIFF
--- a/pronto/static/js/database/signatures.js
+++ b/pronto/static/js/database/signatures.js
@@ -209,7 +209,8 @@ document.addEventListener('DOMContentLoaded', () => {
                 .transition('fade');
         });
 
-    document.querySelector('.ui.comments form button').addEventListener('click', e => {
+    const button = document.querySelector('.ui.comments form button');
+    button.addEventListener('click', e => {
         e.preventDefault();
         const form = e.target.closest('form');
         const accession = form.getAttribute('data-id');
@@ -224,4 +225,9 @@ document.addEventListener('DOMContentLoaded', () => {
                     modals.error(object.error.title, object.error.message);
             });
     });
+
+    comments.addKeyPressEventListener(
+        button.closest('form').querySelector('textarea'),
+        button
+    )
 });

--- a/pronto/static/js/database/unintegrated.js
+++ b/pronto/static/js/database/unintegrated.js
@@ -207,8 +207,8 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     }
 
-    document.querySelector('.ui.comments form button')
-        .addEventListener('click', e => {
+    const button = document.querySelector('.ui.comments form button');
+    button.addEventListener('click', e => {
             e.preventDefault();
             const form = e.target.closest('form');
             const accession = form.getAttribute('data-id');
@@ -223,6 +223,11 @@ document.addEventListener('DOMContentLoaded', () => {
                         modals.error(object.error.title, object.error.message);
                 });
         });
+
+    comments.addKeyPressEventListener(
+        button.closest('form').querySelector('textarea'),
+        button
+    )
 
     const colHeaders = document.querySelectorAll('th[data-sort-by]');
     colHeaders.forEach(node => {

--- a/pronto/static/js/entry/annotations.js
+++ b/pronto/static/js/entry/annotations.js
@@ -667,6 +667,14 @@ class Annotation {
     }
 
     reorder(entryAccession, direction) {
+        const editors= document.querySelectorAll('.annotation > .ui.segment > .ui.form');
+        if (editors.length !== 0) {
+            modals.error(
+                'Cannot reorder while editing',
+                'Please save or cancel all edits before reordering annotations to prevent losing unsaved changes.'
+            );
+            return;
+        }
         const url = `/api/entry/${entryAccession}/annotation/${this.id}/order/${direction}/`;
         fetch(url, { method: 'POST' })
             .then(response => response.json())
@@ -679,11 +687,11 @@ class Annotation {
     }
 
     saveChanges(entryAccession, reason) {
-        let text = this.rawText;
-        if (!reason) {
-            if (this.editorIsOpen) {
-                text = this.element.querySelector('textarea').value;
+        let text;
+        if (this.editorIsOpen) {
+            text = this.element.querySelector('textarea').value;
 
+            if (!reason) {
                 const select = this.element.querySelector('select');
                 reason = select.options[select.selectedIndex].value;
 
@@ -692,9 +700,11 @@ class Annotation {
                 else {
                     select.parentNode.classList.add('error');
                 }
-            } else {
-                return;
             }
+        } else if (reason) {
+            text = this.rawText;
+        } else {
+            return;
         }
 
         let isLLM = this.isLLM;

--- a/pronto/static/js/entry/annotations.js
+++ b/pronto/static/js/entry/annotations.js
@@ -602,6 +602,17 @@ class Annotation {
                 }
             });
         }
+
+        const self = this;
+        this.element.addEventListener('keydown', function (e) {
+            const active = document.activeElement;
+            if (active.tagName === 'TEXTAREA') {
+                if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 's') {
+                    e.preventDefault();
+                    self.saveChanges(entryAccession, null);
+                }
+            }
+        });
     }
 
     openEditor(references) {

--- a/pronto/static/js/entry/entry.js
+++ b/pronto/static/js/entry/entry.js
@@ -9,6 +9,7 @@ import * as go from "./go.js";
 import * as references from "./references.js";
 import * as relationships from "./relationships.js";
 import * as signatures from "./signatures.js";
+import {addKeyPressEventListener} from "../ui/comments.js";
 
 function formatType(type) {
     const arr = type.split(/\s+/);
@@ -120,7 +121,8 @@ document.addEventListener('DOMContentLoaded', () => {
     comments.getEntryComments(accession, 2, document.querySelector('.ui.comments'));
 
     // Event to submit comments
-    document.querySelector('.ui.comments form button').addEventListener('click', (e,) => {
+    const button = document.querySelector('.ui.comments form button');
+    button.addEventListener('click', (e,) => {
         e.preventDefault();
         const form = e.currentTarget.closest('form');
         const textarea = form.querySelector('textarea');
@@ -133,6 +135,11 @@ document.addEventListener('DOMContentLoaded', () => {
                     modals.error(result.error.title, result.error.message);
             });
     });
+
+    comments.addKeyPressEventListener(
+        button.closest('form').querySelector('textarea'),
+        button
+    )
 
     document.getElementById('create-annotation')
         .addEventListener('click', (e,) => {

--- a/pronto/static/js/signature.js
+++ b/pronto/static/js/signature.js
@@ -189,7 +189,8 @@ document.addEventListener('DOMContentLoaded', () => {
             comments.getSignatureComments(accession, 2, document.querySelector(".ui.comments"));
 
             // Even listener to post comments
-            document.querySelector('.ui.comments form button').addEventListener('click', e => {
+            const button = document.querySelector('.ui.comments form button');
+            button.addEventListener('click', e => {
                 e.preventDefault();
                 const form = e.target.closest('form');
                 const accession = form.getAttribute('data-id');
@@ -203,6 +204,11 @@ document.addEventListener('DOMContentLoaded', () => {
                             modals.error(object.error.title, object.error.message);
                     });
             });
+
+            comments.addKeyPressEventListener(
+                button.closest('form').querySelector('textarea'),
+                button
+            )
 
             if (result.abstract || result.llm_abstract) {
                 let abstract;

--- a/pronto/static/js/ui/comments.js
+++ b/pronto/static/js/ui/comments.js
@@ -38,6 +38,15 @@ export function initPopups({element, position, buildUrl, createPopup}) {
         });
 }
 
+export function addKeyPressEventListener(textarea, button) {
+    textarea.addEventListener('keydown', e => {
+        if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 's') {
+            e.preventDefault();
+            button.click();
+        }
+    });
+}
+
 function genEntryOrSignatureLink(accession) {
     const endpoint = /^IPR\d{6}$/.test(accession) ? 'entry' : 'signature';
     return `<a href="/${endpoint}/${accession}/">${accession}</a>`;
@@ -164,5 +173,4 @@ function postComment(type, accession, text) {
         body: JSON.stringify({text: text})
     })
         .then(response => response.json());
-
 }


### PR DESCRIPTION
Hi @blazaropinto,

I've added a keyboard shortcut to create a new CAB, save a CAB being edited, and submit comments. When write in the text area, you can save/submit the annotation/comment with `Ctrl+S` (Windows/Linux) or `Cmd+S` (MacOS), without having to click a button.

I also changed the behaviour of the "Mark as reviewed" and "Mark as curated" buttons: when clicking these, if the annotation editor is open, any change is saved when updating the status. Finally, an error message is displayed when trying to reorder annotations if at least one annotation has its editor mode enabled.

You can try this on the Pronto test instance: http://pronto-tst.ebi.ac.uk:5000/. It is using a test database: any comment you add or annotation you update is **not** going to be visible in the usual Pronto instance.